### PR TITLE
[MRG] 🔧 Bumping version to patch.dev

### DIFF
--- a/srlearn/_meta.py
+++ b/srlearn/_meta.py
@@ -14,6 +14,6 @@ srlearn metadata
 """
 
 __author__ = "Alexander L. Hayes (hayesall)"
-__version__ = "0.5.0"
+__version__ = "0.5.1.dev"
 
 DEBUG = False


### PR DESCRIPTION
The next release should be a patch, bumping version to `0.5.0` to `0.5.1.dev`