### PR TITLE
🐛 Fix name of ignored file in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=srlearn.py
+ignore=boostsrl.py
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.


### PR DESCRIPTION
Fix `boostsrl.py` incorrectly named as `srlearn.py`

The `.pylintrc` was incorrectly updated to include a non-existent file `srlearn.py`