### PR TITLE
[MRG] fix the delimiter of np.loadtxt of predict and predict_proba

### DIFF
--- a/srlearn/rdn.py
+++ b/srlearn/rdn.py
@@ -229,7 +229,7 @@ class BoostedRDN(BaseBoostedRelationalModel):
         )
         _classes, _results = np.loadtxt(
             _results_db,
-            delimiter=" ",
+            delimiter=") ",
             usecols=(0, 1),
             converters={0: lambda s: 0 if s[0] == 33 else 1},
             unpack=True,
@@ -266,7 +266,7 @@ class BoostedRDN(BaseBoostedRelationalModel):
         )
         _classes, _results = np.loadtxt(
             _results_db,
-            delimiter=" ",
+            delimiter=") ",
             usecols=(0, 1),
             converters={0: lambda s: 0 if s[0] == 33 else 1},
             unpack=True,


### PR DESCRIPTION
Fix the issue **"Delimiter issue of np.loadtxt in function predict and predict_proba of rdn.py"** #42, by changing the delimiter from " " to ") " of the function call _**np.loadtxt**_ in both functions _**predict**_ and _**predict_proba**_ of the code file **rdn.py**.