### PR TITLE
✏️ Fixing Badges in README and docs

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,4 +1,4 @@
-name: Package Tests
+name: Ubuntu Build
 on: [push]
 
 jobs:

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ srlearn
 .. image:: https://raw.githubusercontent.com/hayesall/srlearn/master/docs/source/_static/preview.png
     :alt:  Repository preview image: "srlearn. Python wrappers around BoostSRL with a scikit-learn-style interface. pip install srlearn."
 
-|License|_ |LGTM|_ |GitHubBuilds|_ |AppVeyor|_ |Codecov|_|ReadTheDocs|_
+|License|_ |LGTM|_ |GitHubBuilds|_ |AppVeyor|_ |Codecov|_ |ReadTheDocs|_
 
 .. |License| image:: https://img.shields.io/github/license/hayesall/srlearn.svg
     :alt: License

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ srlearn
 .. image:: https://raw.githubusercontent.com/hayesall/srlearn/master/docs/source/_static/preview.png
     :alt:  Repository preview image: "srlearn. Python wrappers around BoostSRL with a scikit-learn-style interface. pip install srlearn."
 
-|License|_ |LGTM|_ |Travis|_ |AppVeyor|_ |Codecov|_ |CircleCi|_ |ReadTheDocs|_
+|License|_ |LGTM|_ |GitHubBuilds|_ |AppVeyor|_ |Codecov|_|ReadTheDocs|_
 
 .. |License| image:: https://img.shields.io/github/license/hayesall/srlearn.svg
     :alt: License

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ srlearn
     :alt: LGTM code quality analysis
 .. _LGTM: https://lgtm.com/projects/g/hayesall/srlearn/context:python
 
-.. |Travis| image:: https://travis-ci.org/hayesall/srlearn.svg?branch=master
-    :alt: Travis CI continuous integration build status
-.. _Travis: https://travis-ci.org/hayesall/srlearn
+.. |GitHubBuilds| image:: https://github.com/hayesall/srlearn/workflows/Package%20Tests/badge.svg
+    :alt: GitHub CI Builds
+.. _GitHubBuilds: https://github.com/hayesall/srlearn/actions?query=workflow%3A%22Package+Tests%22
 
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/obwfhyrjfnfilfce?svg=true
     :alt: AppVeyor Windows build status
@@ -26,9 +26,6 @@ srlearn
 .. |Codecov| image:: https://codecov.io/gh/hayesall/srlearn/branch/master/graphs/badge.svg?branch=master
     :alt: Code coverage status
 .. _Codecov: https://codecov.io/github/hayesall/srlearn?branch=master
-
-.. |CircleCI| image:: https://circleci.com/gh/hayesall/srlearn.svg?style=shield
-.. _CircleCi: https://circleci.com/gh/hayesall/srlearn
 
 .. |ReadTheDocs| image:: https://readthedocs.org/projects/srlearn/badge/?version=latest
     :alt: Documentation status

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ srlearn
 .. image:: _static/preview.png
     :alt:  Repository preview image: "srlearn. Python wrappers around BoostSRL with a scikit-learn-style interface. pip install srlearn."
 
-|License|_ |LGTM|_ |GitHubBuilds|_ |AppVeyor|_ |Codecov|_|ReadTheDocs|_
+|License|_ |LGTM|_ |GitHubBuilds|_ |AppVeyor|_ |Codecov|_ |ReadTheDocs|_
 
 .. |License| image:: https://img.shields.io/github/license/hayesall/srlearn.svg
     :alt: License

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ srlearn
 .. image:: _static/preview.png
     :alt:  Repository preview image: "srlearn. Python wrappers around BoostSRL with a scikit-learn-style interface. pip install srlearn."
 
-|License|_ |LGTM|_ |Travis|_ |AppVeyor|_ |Codecov|_ |CircleCi|_ |ReadTheDocs|_
+|License|_ |LGTM|_ |GitHubBuilds|_ |AppVeyor|_ |Codecov|_|ReadTheDocs|_
 
 .. |License| image:: https://img.shields.io/github/license/hayesall/srlearn.svg
     :alt: License

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,20 +15,17 @@ srlearn
     :alt: LGTM code quality analysis
 .. _LGTM: https://lgtm.com/projects/g/hayesall/srlearn/context:python
 
-.. |Travis| image:: https://travis-ci.org/hayesall/srlearn.svg?branch=master
-    :alt: Travis CI continuous integration build status
-.. _Travis: https://travis-ci.org/hayesall/srlearn
+.. |GitHubBuilds| image:: https://github.com/hayesall/srlearn/workflows/Package%20Tests/badge.svg
+    :alt: GitHub CI Builds
+.. _GitHubBuilds: https://github.com/hayesall/srlearn/actions?query=workflow%3A%22Package+Tests%22
 
-.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/mxi2kffhr7a14rpt?svg=true
+.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/obwfhyrjfnfilfce?svg=true
     :alt: AppVeyor Windows build status
 .. _AppVeyor: https://ci.appveyor.com/project/hayesall/srlearn
 
 .. |Codecov| image:: https://codecov.io/gh/hayesall/srlearn/branch/master/graphs/badge.svg?branch=master
     :alt: Code coverage status
 .. _Codecov: https://codecov.io/github/hayesall/srlearn?branch=master
-
-.. |CircleCI| image:: https://circleci.com/gh/hayesall/srlearn.svg?style=shield
-.. _CircleCi: https://circleci.com/gh/hayesall/srlearn
 
 .. |ReadTheDocs| image:: https://readthedocs.org/projects/srlearn/badge/?version=latest
     :alt: Documentation status


### PR DESCRIPTION
Drop Travis-CI badge
Drop Circle-CI badge
Fix link in `index.rst` pointing to incorrect Appveyor build
Add link to GitHub actions CI build